### PR TITLE
Kill of kGTLRServiceErrorStringKey.

### DIFF
--- a/Source/Objects/GTLRErrorObject.m
+++ b/Source/Objects/GTLRErrorObject.m
@@ -42,7 +42,7 @@
   GTLRErrorObject *object = [self object];
   object->_originalFoundationError = error;
   object.code = @(error.code);
-  object.message = error.description;
+  object.message = error.localizedDescription;
   return object;
 }
 
@@ -60,7 +60,7 @@
 
   // This structured GTLRErrorObject will be available in the error's userInfo
   // dictionary.
-  [userInfo setObject:self forKey:kGTLRStructuredErrorKey];
+  userInfo[kGTLRStructuredErrorKey]  = self;
 
   NSError *error;
   if (_originalFoundationError) {
@@ -70,14 +70,7 @@
   } else {
     NSString *reasonStr = self.message;
     if (reasonStr) {
-      // We always store an error in the userInfo key "error"
-      [userInfo setObject:reasonStr forKey:kGTLRServiceErrorStringKey];
-
-      // Store a user-readable "reason" to show up when an error is logged,
-      // in parentheses like NSError does it
-      NSString *parenthesized = [NSString stringWithFormat:@"(%@)", reasonStr];
-      [userInfo setObject:parenthesized
-                   forKey:NSLocalizedFailureReasonErrorKey];
+      userInfo[NSLocalizedDescriptionKey] = reasonStr;
     }
 
     error = [NSError errorWithDomain:kGTLRErrorObjectDomain

--- a/Source/Objects/GTLRService.h
+++ b/Source/Objects/GTLRService.h
@@ -68,11 +68,6 @@ extern NSString *const kGTLRServiceErrorContentIDKey;
 extern NSString *const kGTLRErrorObjectDomain;
 
 /**
- *  The userInfo key for the server error string for errors with domain kGTLRErrorObjectDomain.
- */
-extern NSString *const kGTLRServiceErrorStringKey;
-
-/**
  *  The userInfo key for a GTLRErrorObject for errors with domain kGTLRErrorObjectDomain
  *  when the error was created from a structured JSON error response body.
  */
@@ -149,7 +144,7 @@ typedef void (^GTLRServiceUploadProgressBlock)(GTLRServiceTicket *progressTicket
  *                            kGTMSessionFetcherStatusDomain then the error's code is the server
  *                            response status.  Details on the error from the server are available
  *                            in the userInfo via the keys kGTLRStructuredErrorKey and
- *                            kGTLRServiceErrorStringKey.
+ *                            NSLocalizedDescriptionKey.
  *
  *  @return YES if the request should be retried.
  */

--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -36,7 +36,6 @@
 
 NSString *const kGTLRServiceErrorDomain = @"com.google.GTLRServiceDomain";
 NSString *const kGTLRErrorObjectDomain = @"com.google.GTLRErrorObjectDomain";
-NSString *const kGTLRServiceErrorStringKey = @"error";
 NSString *const kGTLRServiceErrorBodyDataKey = @"body";
 NSString *const kGTLRServiceErrorContentIDKey = @"contentID";
 NSString *const kGTLRStructuredErrorKey = @"GTLRStructuredError";
@@ -769,7 +768,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
             // error response visible in the error object.
             NSString *reasonStr = [[NSString alloc] initWithData:(NSData * _Nonnull)data
                                                         encoding:NSUTF8StringEncoding];
-            NSDictionary *userInfo = @{ NSLocalizedFailureReasonErrorKey : reasonStr };
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : reasonStr };
             error = [NSError errorWithDomain:kGTMSessionFetcherStatusDomain
                                         code:status
                                     userInfo:userInfo];
@@ -1582,7 +1581,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
         // Report a fetch failure for this part that lacks a JSON error.
         NSString *errorStr = responsePart.statusString;
         NSDictionary *userInfo = @{
-          kGTLRServiceErrorStringKey : (errorStr ?: @"<unknown>"),
+          NSLocalizedDescriptionKey : (errorStr ?: @"<unknown>"),
         };
         NSError *httpError = [NSError errorWithDomain:kGTLRServiceErrorDomain
                                                  code:GTLRServiceErrorBatchResponseStatusCode

--- a/Source/Tests/GTLRErrorObjectTest.m
+++ b/Source/Tests/GTLRErrorObjectTest.m
@@ -64,8 +64,8 @@
   // Test conversion to and from an NSError.
   NSError *fabricatedNSError = errorObj.foundationError;
   XCTAssertEqualObjects(fabricatedNSError.domain, kGTLRErrorObjectDomain);
-  // We always store a string in the userInfo "error" key.
-  NSString *errorStr = fabricatedNSError.userInfo[kGTLRServiceErrorStringKey];
+  // We always store a string in the localizedDescription.
+  NSString *errorStr = fabricatedNSError.localizedDescription;
   XCTAssertGreaterThan(errorStr.length, 0U);
 
   GTLRErrorObject *recoveredErrorObj = [GTLRErrorObject underlyingObjectForError:fabricatedNSError];
@@ -90,8 +90,8 @@
   // Test conversion to and from an NSError.
   NSError *fabricatedNSError = errorObj.foundationError;
   XCTAssertEqualObjects(fabricatedNSError.domain, kGTLRErrorObjectDomain);
-  // We always store a string in the userInfo "error" key.
-  NSString *errorStr = fabricatedNSError.userInfo[kGTLRServiceErrorStringKey];
+  NSString *errorStr = fabricatedNSError.localizedDescription;
+  // We always store a string in the localizedDescription.
   XCTAssertGreaterThan(errorStr.length, 0U);
 
   GTLRErrorObject *recoveredErrorObj = [GTLRErrorObject underlyingObjectForError:fabricatedNSError];


### PR DESCRIPTION
Instead use localizedDescription, and that's likely what more developers will
be looking for.