### PR TITLE
Complete NSObject & NSSecureEncoding support on GTLRObject subclasses.

### DIFF
--- a/Source/Objects/GTLRBatchResult.m
+++ b/Source/Objects/GTLRBatchResult.m
@@ -20,12 +20,22 @@
 #import "GTLRBatchResult.h"
 
 #import "GTLRErrorObject.h"
+#import "GTLRUtilities.h"
+
+static NSString *const kGTLRBatchResultSuccessesKeys = @"successesKeys";
+static NSString *const kGTLRBatchResultSuccessKeyPrefix = @"Success-";
+static NSString *const kGTLRBatchResultFailuresKeys = @"failuresKeys";
+static NSString *const kGTLRBatchResultFailurKeyPrefix = @"Failure-";
+static NSString *const kGTLRBatchResultResponseHeaders = @"responseHeaders";
 
 @implementation GTLRBatchResult
 
 @synthesize successes = _successes,
             failures = _failures,
             responseHeaders = _responseHeaders;
+
+// Since this class doesn't use the json property, provide the basic NSObject
+// methods needed to ensure proper behaviors.
 
 - (id)copyWithZone:(NSZone *)zone {
   GTLRBatchResult* newObject = [super copyWithZone:zone];
@@ -35,10 +45,124 @@
   return newObject;
 }
 
+- (NSUInteger)hash {
+  NSUInteger result = [super hash];
+  result += result * 13 + [self.successes hash];
+  result += result * 13 + [self.failures hash];
+  result += result * 13 + [self.responseHeaders hash];
+  return result;
+}
+
+- (BOOL)isEqual:(id)object {
+  if (self == object) return YES;
+
+  if (![super isEqual:object]) {
+    return NO;
+  }
+
+  if (![object isKindOfClass:[GTLRBatchResult class]]) {
+    return NO;
+  }
+
+  GTLRBatchResult *other = (GTLRBatchResult *)object;
+  if (!GTLR_AreEqualOrBothNil(self.successes, other.successes)) {
+    return NO;
+  }
+  if (!GTLR_AreEqualOrBothNil(self.failures, other.failures)) {
+    return NO;
+  }
+  return GTLR_AreEqualOrBothNil(self.responseHeaders, other.responseHeaders);
+}
+
 - (NSString *)description {
   return [NSString stringWithFormat:@"%@ %p (successes:%tu failures:%tu responseHeaders:%tu)",
           [self class], self,
           self.successes.count, self.failures.count, self.responseHeaders.count];
+}
+
+// This class is a subclass of GTLRObject, which declares NSSecureCoding
+// conformance. Since this class does't really use the json property, provide
+// a custom implementation to maintain the contract.
+//
+// For success/failures, one could do:
+//    [encoder encodeObject:self.successes forKey:kGTLRBatchResultSuccesses];
+//    [encoder encodeObject:self.failures forKey:kGTLRBatchResultFailuresKeys];
+// and then use -decodeObjectOfClasses:forKey:, but nothing actually checks the
+// structure of the dictionary, so instead the dicts are blown out to provide
+// better validation by the encoder/decoder.
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    NSArray<NSString *> *keys =
+        [decoder decodeObjectOfClass:[NSArray class]
+                              forKey:kGTLRBatchResultSuccessesKeys];
+    if (keys.count) {
+      NSMutableDictionary *dict =
+          [NSMutableDictionary dictionaryWithCapacity:keys.count];
+      for (NSString *key in keys) {
+        NSString *storageKey =
+            [kGTLRBatchResultSuccessKeyPrefix stringByAppendingString:key];
+        GTLRObject *obj = [decoder decodeObjectOfClass:[GTLRObject class]
+                                                forKey:storageKey];
+        if (obj) {
+          [dict setObject:obj forKey:key];
+        }
+      }
+      self.successes = dict;
+    }
+
+    keys = [decoder decodeObjectOfClass:[NSArray class]
+                                 forKey:kGTLRBatchResultFailuresKeys];
+    if (keys.count) {
+      NSMutableDictionary *dict =
+          [NSMutableDictionary dictionaryWithCapacity:keys.count];
+      for (NSString *key in keys) {
+        NSString *storageKey =
+            [kGTLRBatchResultFailurKeyPrefix stringByAppendingString:key];
+        GTLRObject *obj = [decoder decodeObjectOfClass:[GTLRObject class]
+                                                forKey:storageKey];
+        if (obj) {
+          [dict setObject:obj forKey:key];
+        }
+      }
+      self.failures = dict;
+    }
+
+    self.responseHeaders =
+        [decoder decodeObjectOfClass:[NSDictionary class]
+                              forKey:kGTLRBatchResultResponseHeaders];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+  [super encodeWithCoder:encoder];
+  [encoder encodeObject:self.successes.allKeys
+                 forKey:kGTLRBatchResultSuccessesKeys];
+  [self.successes enumerateKeysAndObjectsUsingBlock:^(NSString *key,
+                                                      GTLRObject * obj,
+                                                      BOOL * stop) {
+    NSString *storageKey =
+        [kGTLRBatchResultSuccessKeyPrefix stringByAppendingString:key];
+    [encoder encodeObject:obj forKey:storageKey];
+  }];
+
+  [encoder encodeObject:self.failures.allKeys forKey:kGTLRBatchResultFailuresKeys];
+  [self.failures enumerateKeysAndObjectsUsingBlock:^(NSString *key,
+                                                     GTLRObject * obj,
+                                                     BOOL * stop) {
+    NSString *storageKey =
+        [kGTLRBatchResultFailurKeyPrefix stringByAppendingString:key];
+    [encoder encodeObject:obj forKey:storageKey];
+  }];
+
+  [encoder encodeObject:self.responseHeaders
+                 forKey:kGTLRBatchResultResponseHeaders];
 }
 
 @end

--- a/Source/Objects/GTLRErrorObject.m
+++ b/Source/Objects/GTLRErrorObject.m
@@ -18,7 +18,11 @@
 #endif
 
 #import "GTLRErrorObject.h"
+
+#import "GTLRUtilities.h"
 #import "GTLRService.h"
+
+static NSString *const kGTLRErrorObjectFoundationErrorKey = @"foundationError";
 
 @implementation GTLRErrorObject {
   NSError *_originalFoundationError;
@@ -84,6 +88,36 @@
   NSDictionary *userInfo = [foundationError userInfo];
   GTLRErrorObject *errorObj = [userInfo objectForKey:kGTLRStructuredErrorKey];
   return errorObj;
+}
+
+- (BOOL)isEqual:(id)object {
+  // Include the underlying foundation error in equality checks.
+  if (self == object) return YES;
+  if (![super isEqual:object]) return NO;
+  if (![object isKindOfClass:[GTLRErrorObject class]]) return NO;
+  GTLRErrorObject *other = (GTLRErrorObject *)object;
+  return GTLR_AreEqualOrBothNil(_originalFoundationError,
+                                other->_originalFoundationError);
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+  self = [super initWithCoder:decoder];
+  if (self) {
+    _originalFoundationError =
+        [decoder decodeObjectOfClass:[NSError class]
+                              forKey:kGTLRErrorObjectFoundationErrorKey];
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+  [super encodeWithCoder:encoder];
+  [encoder encodeObject:_originalFoundationError
+                 forKey:kGTLRErrorObjectFoundationErrorKey];
 }
 
 @end

--- a/Source/Tests/GTLRErrorObjectTest.m
+++ b/Source/Tests/GTLRErrorObjectTest.m
@@ -116,4 +116,54 @@
   XCTAssertEqualObjects(recoveredErrorObj.JSON, errorObj.JSON);
 }
 
+- (void)testObjectCoding {
+  XCTAssertTrue([GTLRErrorObject supportsSecureCoding]);
+
+  // Make sure the underlying JSON support didn't get busted.
+
+  GTLRErrorObject *obj = [GTLRErrorObject object];
+  obj.code = @123;
+  obj.message = @"A message";
+
+  NSMutableData *data = [NSMutableData data];
+  NSKeyedArchiver *archiver =
+      [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
+  [archiver setRequiresSecureCoding:YES];
+  [archiver encodeObject:obj forKey:NSKeyedArchiveRootObjectKey];
+  [archiver finishEncoding];
+  XCTAssertTrue(data.length > 0);
+
+  NSKeyedUnarchiver *unarchiver =
+      [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+  [unarchiver setRequiresSecureCoding:YES];
+  GTLRErrorObject *obj2 =
+      [unarchiver decodeObjectOfClass:[GTLRErrorObject class]
+                               forKey:NSKeyedArchiveRootObjectKey];
+  XCTAssertNotNil(obj2);
+  XCTAssertNotEqual(obj, obj2);  // Pointer compare
+  XCTAssertEqualObjects(obj, obj2);
+
+  // Test with a foundation error.
+
+  NSError *err = [NSError errorWithDomain:@"my.domain"
+                                     code:111
+                                 userInfo:nil];
+  obj = [GTLRErrorObject objectWithFoundationError:err];
+
+  data = [NSMutableData data];
+  archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
+  [archiver setRequiresSecureCoding:YES];
+  [archiver encodeObject:obj forKey:NSKeyedArchiveRootObjectKey];
+  [archiver finishEncoding];
+  XCTAssertTrue(data.length > 0);
+
+  unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+  [unarchiver setRequiresSecureCoding:YES];
+  obj2 = [unarchiver decodeObjectOfClass:[GTLRErrorObject class]
+                                  forKey:NSKeyedArchiveRootObjectKey];
+  XCTAssertNotNil(obj2);
+  XCTAssertNotEqual(obj, obj2);  // Pointer compare.
+  XCTAssertEqualObjects(obj, obj2);
+}
+
 @end


### PR DESCRIPTION
- Add isEqual: and hash where it makes sense because of ivars outside the
  JSON support from the base class.
- Add unittests to ensure encode/decode works.

Fixes https://github.com/google/google-api-objectivec-client-for-rest/issues/36