### PR TITLE
Flush user defaults to disk on exit.

### DIFF
--- a/Examples/CalendarSample/CalendarSampleAppController.h
+++ b/Examples/CalendarSample/CalendarSampleAppController.h
@@ -19,5 +19,5 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface CalendarSampleAppController : NSObject
+@interface CalendarSampleAppController : NSObject<NSApplicationDelegate>
 @end

--- a/Examples/CalendarSample/CalendarSampleAppController.m
+++ b/Examples/CalendarSample/CalendarSampleAppController.m
@@ -28,6 +28,11 @@
   [windowController showWindow:self];
 }
 
+- (void)applicationWillTerminate:(NSNotification *)notification {
+  // Ensure any defaults are flushed out.
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
   return YES;
 }

--- a/Examples/DriveSample/DriveSampleAppController.h
+++ b/Examples/DriveSample/DriveSampleAppController.h
@@ -19,5 +19,5 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface DriveSampleAppController : NSObject
+@interface DriveSampleAppController : NSObject<NSApplicationDelegate>
 @end

--- a/Examples/DriveSample/DriveSampleAppController.m
+++ b/Examples/DriveSample/DriveSampleAppController.m
@@ -28,6 +28,11 @@
   [windowController showWindow:self];
 }
 
+- (void)applicationWillTerminate:(NSNotification *)notification {
+  // Ensure any defaults are flushed out.
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
   return YES;
 }

--- a/Examples/StorageSample/StorageSampleAppController.h
+++ b/Examples/StorageSample/StorageSampleAppController.h
@@ -19,5 +19,5 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface StorageSampleAppController : NSObject
+@interface StorageSampleAppController : NSObject<NSApplicationDelegate>
 @end

--- a/Examples/StorageSample/StorageSampleAppController.m
+++ b/Examples/StorageSample/StorageSampleAppController.m
@@ -28,6 +28,11 @@
   [windowController showWindow:self];
 }
 
+- (void)applicationWillTerminate:(NSNotification *)notification {
+  // Ensure any defaults are flushed out.
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
   return YES;
 }

--- a/Examples/YouTubeSample/YouTubeSampleAppController.h
+++ b/Examples/YouTubeSample/YouTubeSampleAppController.h
@@ -19,5 +19,5 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface YouTubeSampleAppController : NSObject
+@interface YouTubeSampleAppController : NSObject<NSApplicationDelegate>
 @end

--- a/Examples/YouTubeSample/YouTubeSampleAppController.m
+++ b/Examples/YouTubeSample/YouTubeSampleAppController.m
@@ -32,6 +32,11 @@
   [windowController showWindow:self];
 }
 
+- (void)applicationWillTerminate:(NSNotification *)notification {
+  // Ensure any defaults are flushed out.
+  [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
   return YES;
 }


### PR DESCRIPTION
This came up in https://github.com/google/google-api-objectivec-client-for-rest/issues/35
and I've seen the issue myself before.  If you are too quick, some defaults
don't get written and you have to re-enter the data the next time your run the
app. Should avoid some developer confusion.