### PR TITLE
Added CFBundleShortVersionString for iOS framework

### DIFF
--- a/Source/Resources/GTLRiOSFramework-Info.plist
+++ b/Source/Resources/GTLRiOSFramework-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Resources/GTLRiOSFramework-Info.plist
+++ b/Source/Resources/GTLRiOSFramework-Info.plist
@@ -12,6 +12,8 @@
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This is required by app to be submitted to App Store