### PR TITLE
Fix skip install for macOS

### DIFF
--- a/Source/GTLRCore.xcodeproj/project.pbxproj
+++ b/Source/GTLRCore.xcodeproj/project.pbxproj
@@ -2242,6 +2242,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLR;
 				PRODUCT_NAME = GTLR;
+				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
 			};
 			name = Debug;
@@ -2261,6 +2262,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLR;
 				PRODUCT_NAME = GTLR;
+				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
 			};
 			name = Release;


### PR DESCRIPTION
Set `SKIP_INSTALL = YES` for GTLROSXCore build configurations as referenced in this issue: https://github.com/google/google-api-objectivec-client-for-rest/issues/124

Submitted on behalf of Zetetic, LLC