### PR TITLE
Tweak OAuth2 Scope Name generation.

### DIFF
--- a/Source/GeneratedServices/Script/GTLRScriptQuery.h
+++ b/Source/GeneratedServices/Script/GTLRScriptQuery.h
@@ -47,12 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  *  Authorization scope(s):
  *    @c kGTLRAuthScopeScriptAdminDirectoryGroup
  *    @c kGTLRAuthScopeScriptAdminDirectoryUser
+ *    @c kGTLRAuthScopeScriptCalendarFeeds
  *    @c kGTLRAuthScopeScriptDrive
- *    @c kGTLRAuthScopeScriptFeeds
- *    @c kGTLRAuthScopeScriptFeeds
  *    @c kGTLRAuthScopeScriptForms
  *    @c kGTLRAuthScopeScriptFormsCurrentonly
  *    @c kGTLRAuthScopeScriptGroups
+ *    @c kGTLRAuthScopeScriptM8Feeds
  *    @c kGTLRAuthScopeScriptMailGoogleCom
  *    @c kGTLRAuthScopeScriptSpreadsheets
  *    @c kGTLRAuthScopeScriptUserinfoEmail

--- a/Source/GeneratedServices/Script/GTLRScriptService.h
+++ b/Source/GeneratedServices/Script/GTLRScriptService.h
@@ -38,17 +38,17 @@ GTLR_EXTERN NSString * const kGTLRAuthScopeScriptAdminDirectoryGroup;
  */
 GTLR_EXTERN NSString * const kGTLRAuthScopeScriptAdminDirectoryUser;
 /**
+ *  Authorization scope: Manage your calendars
+ *
+ *  Value "https://www.google.com/calendar/feeds"
+ */
+GTLR_EXTERN NSString * const kGTLRAuthScopeScriptCalendarFeeds;
+/**
  *  Authorization scope: View and manage the files in your Google Drive
  *
  *  Value "https://www.googleapis.com/auth/drive"
  */
 GTLR_EXTERN NSString * const kGTLRAuthScopeScriptDrive;
-/**
- *  Authorization scope: Manage your calendars
- *
- *  Value "https://www.google.com/calendar/feeds"
- */
-GTLR_EXTERN NSString * const kGTLRAuthScopeScriptFeeds;
 /**
  *  Authorization scope: View and manage your forms in Google Drive
  *
@@ -68,6 +68,12 @@ GTLR_EXTERN NSString * const kGTLRAuthScopeScriptFormsCurrentonly;
  *  Value "https://www.googleapis.com/auth/groups"
  */
 GTLR_EXTERN NSString * const kGTLRAuthScopeScriptGroups;
+/**
+ *  Authorization scope: Manage your contacts
+ *
+ *  Value "https://www.google.com/m8/feeds"
+ */
+GTLR_EXTERN NSString * const kGTLRAuthScopeScriptM8Feeds;
 /**
  *  Authorization scope: Read, send, delete, and manage your email
  *

--- a/Source/GeneratedServices/Script/GTLRScriptService.m
+++ b/Source/GeneratedServices/Script/GTLRScriptService.m
@@ -15,11 +15,12 @@
 
 NSString * const kGTLRAuthScopeScriptAdminDirectoryGroup = @"https://www.googleapis.com/auth/admin.directory.group";
 NSString * const kGTLRAuthScopeScriptAdminDirectoryUser  = @"https://www.googleapis.com/auth/admin.directory.user";
+NSString * const kGTLRAuthScopeScriptCalendarFeeds       = @"https://www.google.com/calendar/feeds";
 NSString * const kGTLRAuthScopeScriptDrive               = @"https://www.googleapis.com/auth/drive";
-NSString * const kGTLRAuthScopeScriptFeeds               = @"https://www.google.com/calendar/feeds";
 NSString * const kGTLRAuthScopeScriptForms               = @"https://www.googleapis.com/auth/forms";
 NSString * const kGTLRAuthScopeScriptFormsCurrentonly    = @"https://www.googleapis.com/auth/forms.currentonly";
 NSString * const kGTLRAuthScopeScriptGroups              = @"https://www.googleapis.com/auth/groups";
+NSString * const kGTLRAuthScopeScriptM8Feeds             = @"https://www.google.com/m8/feeds";
 NSString * const kGTLRAuthScopeScriptMailGoogleCom       = @"https://mail.google.com/";
 NSString * const kGTLRAuthScopeScriptSpreadsheets        = @"https://www.googleapis.com/auth/spreadsheets";
 NSString * const kGTLRAuthScopeScriptUserinfoEmail       = @"https://www.googleapis.com/auth/userinfo.email";


### PR DESCRIPTION
I finally went looking to see why "script" wants to regenerate, and realized
it isn't server flake, but actually the generator causes two of the scopes to
end up generating the same name, so it depends on the iteration order during
generation for who "wins".

Rewrite the scope generation:
- Support not trying to do any cleanup, and just use the whole raw scope string.
- Pick off the Google auth prefix pattern since that has a defined pattern.
- Pull apart things that see to be urls.
  - Drop the host name if there is more after it.
  - At this point there are two modes, using the last path segment or using the
    full thing.

Add a preflight check up front to try the different modes and see what doesn't
make collisions. If everything results in collisions, error out instead of
silently letting things go.