### PR TITLE
Update auto defines for CocoaPods.

### DIFF
--- a/GoogleAPIClientForREST.podspec
+++ b/GoogleAPIClientForREST.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
 
-  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GTLR_USE_FRAMEWORK_IMPORTS=1 GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT=1' }
-
   # Require at least 1.1.7 of the SessionFetcher for some changes in that
   # project's headers.
   s.dependency 'GTMSessionFetcher', '>= 1.1.7'

--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -24,7 +24,11 @@
 #endif
 
 #if !defined(GTLR_USE_FRAMEWORK_IMPORTS)
-  #define GTLR_USE_FRAMEWORK_IMPORTS 0
+  #if defined(COCOAPODS) && COCOAPODS
+    #define GTLR_USE_FRAMEWORK_IMPORTS 1
+  #else
+    #define GTLR_USE_FRAMEWORK_IMPORTS 0
+  #endif
 #endif
 
 #import "GTLRService.h"
@@ -154,7 +158,11 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
 @end
 
 #if !defined(GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT)
-#define GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT 0
+  #if defined(COCOAPODS) && COCOAPODS
+    #define GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT 1
+  #else
+    #define GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT 0
+  #endif
 #endif
 
 #if GTLR_HAS_SESSION_UPLOAD_FETCHER_IMPORT


### PR DESCRIPTION
Instead of relying on the podspec to force things into the generated projects,
use the CPP symbols CocoaPods provides (https://github.com/CocoaPods/CocoaPods/issues/903)
to auto define things for a build that is CocoaPods based. The CPP symbols
still support explicitly setting them should a developer need it.