### PR TITLE
Add explicit (long) casts to NSInteger format args.

### DIFF
--- a/Source/Objects/GTLRDateTime.m
+++ b/Source/Objects/GTLRDateTime.m
@@ -203,7 +203,7 @@ static NSUInteger const kGTLRDateComponentBits = (NSCalendarUnitYear | NSCalenda
       NSInteger mins = offsetVal % 60;
       NSInteger hours = (offsetVal - mins) / 60;
       offsetStr = [NSString stringWithFormat:@"%c%02zd:%02zd",
-                   isNegative ? '-' : '+', hours, mins];
+                   isNegative ? '-' : '+', (long)hours, (long)mins];
 
       // Adjust date components back to account for the offset.
       //
@@ -218,14 +218,15 @@ static NSUInteger const kGTLRDateComponentBits = (NSCalendarUnitYear | NSCalenda
     }
 
     timeString = [NSString stringWithFormat:@"T%02zd:%02zd:%02zd%@%@",
-                  dateComponents.hour, dateComponents.minute,
-                  dateComponents.second, fractionalSecondsString,
+                  (long)dateComponents.hour, (long)dateComponents.minute,
+                  (long)dateComponents.second, fractionalSecondsString,
                   offsetStr];
   }
 
   // full dateString like "2006-11-17T15:10:46-08:00"
   NSString *dateString = [NSString stringWithFormat:@"%04zd-%02zd-%02zd%@",
-    dateComponents.year, dateComponents.month, dateComponents.day, timeString];
+    (long)dateComponents.year, (long)dateComponents.month,
+    (long)dateComponents.day, timeString];
 
   @synchronized(self) {
     _cachedRFC3339String = dateString;


### PR DESCRIPTION
In newest version of clang, format arguments of NSInteger type need to
be explicitly cast to (long) on 32-bit platforms (-Wformat). Adds said
casts.