### PR TITLE
Drop legacy object naming support.

### DIFF
--- a/Source/Tools/ServiceGenerator/SGGenerator.h
+++ b/Source/Tools/ServiceGenerator/SGGenerator.h
@@ -30,8 +30,7 @@ typedef NS_OPTIONS(NSUInteger, SGGeneratorOptions) {
   kSGGeneratorOptionAuditJSON               = 1 << 0,
   kSGGeneratorOptionAllowRootOverride       = 1 << 1,
   kSGGeneratorOptionAllowGuessFormattedName = 1 << 2,
-  kSGGeneratorOptionLegacyObjectNaming      = 1 << 3,
-  kSGGeneratorOptionImportPrefixIsFramework = 1 << 4,
+  kSGGeneratorOptionImportPrefixIsFramework = 1 << 3,
 };
 
 @interface SGGenerator : NSObject

--- a/Source/Tools/ServiceGenerator/SGGenerator.m
+++ b/Source/Tools/ServiceGenerator/SGGenerator.m
@@ -160,7 +160,6 @@ typedef enum {
 @interface SGGenerator ()
 @property(strong) NSMutableArray *warnings;
 @property(strong) NSMutableArray *infos;
-@property(readonly) BOOL useLegacyObjectNaming;
 @end
 
 // Helper to get the objects of a dictionary out in a sorted order.
@@ -407,11 +406,6 @@ static void CheckForUnknownJSON(GTLRObject *obj, NSArray *keyPath,
 
 - (BOOL)auditJSON {
   BOOL result = (_options & kSGGeneratorOptionAuditJSON) != 0;
-  return result;
-}
-
-- (BOOL)useLegacyObjectNaming {
-  BOOL result = (_options & kSGGeneratorOptionLegacyObjectNaming) != 0;
   return result;
 }
 
@@ -764,10 +758,6 @@ static void CheckForUnknownJSON(GTLRObject *obj, NSArray *keyPath,
         [NSString stringWithFormat:@"Collision over the class name '%@' (schemas '%@' and '%@')",
          objcClassName,
          previousSchema.sg_fullSchemaName, schema.sg_fullSchemaName];
-      if (self.useLegacyObjectNaming) {
-        errStr =
-            [errStr stringByAppendingString:@", not using --useLegacyObjectClassNames will likely avoid this."];
-      }
       messageHandler(kSGGeneratorHandlerMessageError, errStr);
       allGood = NO;
     } else {
@@ -4003,9 +3993,7 @@ static NSString *OverrideName(NSString *name, EQueryOrObject queryOrObject,
   NSString *result = [resolvedSchema sg_propertyForKey:kSchemaObjCClassNameKey];
   if (result == nil) {
     NSArray *parts = [resolvedSchema sg_fullSchemaPath:YES foldArrayItems:YES];
-    SGGenerator *generator = self.sg_generator;
-    NSString *joiner = (generator.useLegacyObjectNaming ? @"" : @"_");
-    NSString *fullName = [parts componentsJoinedByString:joiner];
+    NSString *fullName = [parts componentsJoinedByString:@"_"];
 
     result = [NSString stringWithFormat:@"%@%@_%@",
               kProjectPrefix, self.sg_generator.formattedAPIName, fullName];

--- a/Source/Tools/ServiceGenerator/SGMain.m
+++ b/Source/Tools/ServiceGenerator/SGMain.m
@@ -110,11 +110,6 @@ static ArgInfo optionalFlags[] = {
     "Causes any API root URL for a Google sandbox server to be replaced with"
     " the googleapis.com root instead."
   },
-  {
-    "--useLegacyObjectClassNames yes|no  Default: no",
-    "Causes the generated names for object classes to not use underscores to"
-    " provide scoping of nested classes. This can result in naming collisions."
-  },
   { "--messageFilter PATH",
     "A json file containing the the expected messages that should be suppressed"
     " during generation. The content is a dictionary with keys 'INFO' and "
@@ -181,7 +176,6 @@ static const char *kEmBegin          = "";
 static const char *kEmEnd            = "";
 
 static NSString *kGlobalFormattedNameKey = @"__*__";
-static NSString *kGlobalLegacyNamesKey = @"__*__";
 
 typedef enum {
   SGMain_ParseArgs,
@@ -224,7 +218,6 @@ typedef enum {
 @property(assign) NSUInteger verboseLevel;
 @property(strong) NSMutableDictionary *additionalHTTPHeaders;
 @property(strong) NSMutableDictionary *formattedNames;
-@property(strong) NSMutableSet *apisUsingLegacyObjectNaming;
 
 @property(strong) GTLRDiscoveryService *discoveryService;
 @property(strong) NSMutableArray *apisToFetch;
@@ -299,7 +292,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
             briefOutput = _briefOutput,
             additionalHTTPHeaders = _additionalHTTPHeaders,
             formattedNames = _formattedNames,
-            apisUsingLegacyObjectNaming = _apisUsingLegacyObjectNaming,
             discoveryService = _discoveryService,
             numberOfActiveNetworkActions = _numberOfActiveNetworkActions,
             apisToFetch = _apisToFetch,
@@ -320,7 +312,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
     _appName = [[NSString alloc] initWithUTF8String:basename(self.argv[0])];
     _additionalHTTPHeaders = [[NSMutableDictionary alloc] init];
     _formattedNames = [[NSMutableDictionary alloc] init];
-    _apisUsingLegacyObjectNaming = [[NSMutableSet alloc] init];
     _apisToFetch = [[NSMutableArray alloc] init];
     _apisToSkip = [[NSMutableSet alloc] init];
     _collectedApis = [[NSMutableArray alloc] init];
@@ -738,25 +729,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
   }
 }
 
-- (void)parseLegacyNamingArg:(NSString *)arg {
-  // The arg is documented as "yes|no", but we support a list of services to
-  // handle --generatePreferred and keeping a set of things in the old mode.
-  if (([arg caseInsensitiveCompare:@"y"] == NSOrderedSame) ||
-      ([arg caseInsensitiveCompare:@"yes"] == NSOrderedSame)) {
-    [self.apisUsingLegacyObjectNaming addObject:kGlobalLegacyNamesKey];
-  } else if (([arg caseInsensitiveCompare:@"n"] == NSOrderedSame) ||
-             ([arg caseInsensitiveCompare:@"no"] == NSOrderedSame)) {
-    // Nothing to store this is the default.
-  } else {
-    // Split on comma, and store them off.
-    for (NSString *apiName in [arg componentsSeparatedByString:@","]) {
-      if (apiName.length) {
-        [self.apisUsingLegacyObjectNaming addObject:apiName];
-      }
-    }
-  }
-}
-
 - (void)stateParseArgs {
   int generatePreferred = 0;
   int auditJSON = 0;
@@ -777,7 +749,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
     { "addServiceNameDir",   required_argument, NULL,                 'x' },
     { "removeUnknownFiles",  required_argument, NULL,                 'y' },
     { "rootURLOverrides",    required_argument, NULL,                 'u' },
-    { "useLegacyObjectClassNames", required_argument, NULL,           'z' },
     { "messageFilter",       required_argument, NULL,                 'f' },
     { "auditJSON",           no_argument,       &auditJSON,           1 },
     { "guessFormattedNames", no_argument,       &guessFormattedNames, 1 },
@@ -841,9 +812,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
         break;
       case 'u':
         self.rootURLOverrides = [SGUtils boolFromArg:optarg];
-        break;
-      case 'z':
-        [self parseLegacyNamingArg:@(optarg)];
         break;
       case 0:
         // Was a flag, nothing to do.
@@ -1383,11 +1351,6 @@ static BOOL HaveFileStringsChanged(NSString *oldFile, NSString *newFile) {
         }
         if (self.guessFormattedNames) {
           options |= kSGGeneratorOptionAllowGuessFormattedName;
-        }
-        if ([self.apisUsingLegacyObjectNaming containsObject:kGlobalLegacyNamesKey] ||
-            [self.apisUsingLegacyObjectNaming containsObject:api.name] ||
-            [self.apisUsingLegacyObjectNaming containsObject:apiVersion]) {
-          options |= kSGGeneratorOptionLegacyObjectNaming;
         }
 
         NSString *importPrefix = self.gtlrImportPrefix;


### PR DESCRIPTION
Can result in collisions, and hasn't been the default for a while, so
prune the code.