### PR TITLE
Update GTLRDateTime.m

### DIFF
--- a/Source/Objects/GTLRDateTime.m
+++ b/Source/Objects/GTLRDateTime.m
@@ -193,7 +193,7 @@ static NSUInteger const kGTLRDateComponentBits = (NSCalendarUnitYear | NSCalenda
     // and adjust the time.
     NSString *offsetStr = @"Z";
     NSNumber *offsetMinutes = self.offsetMinutes;
-    if (offsetMinutes) {
+    if (offsetMinutes != nil) {
       BOOL isNegative = NO;
       NSInteger offsetVal = offsetMinutes.integerValue;
       if (offsetVal < 0) {


### PR DESCRIPTION
Fix static analysis warning : 
`GTLRDateTime.m:196:9: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`