### PR TITLE
Update GTLRUtilities.m

### DIFF
--- a/Source/Utilities/GTLRUtilities.m
+++ b/Source/Utilities/GTLRUtilities.m
@@ -109,7 +109,7 @@ NSNumber *GTLR_EnsureNSNumber(NSNumber *num) {
         newNum = @(ull);
       }
     }
-    if (newNum) {
+    if (newNum != nil) {
       num = newNum;
     }
   }


### PR DESCRIPTION
Fix static analysis warning for

`GTLRUtilities.m:112:9: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`