### PR TITLE
Update GTLRService.m

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -2473,7 +2473,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
 
     _objectClassResolver = params.objectClassResolver ?: service.objectClassResolver;
 
-    _retryEnabled = (params.retryEnabled ? params.retryEnabled.boolValue : service.retryEnabled);
+    _retryEnabled = ((params.retryEnabled != nil) ? params.retryEnabled.boolValue : service.retryEnabled);
     _maxRetryInterval = (params.maxRetryInterval ?
                          params.maxRetryInterval.doubleValue : service.maxRetryInterval);
     _shouldFetchNextPages = (params.shouldFetchNextPages ?


### PR DESCRIPTION
Fix static analysis warning:
`GTLRService.m:2476:22: Converting a pointer value of type 'NSNumber * _Nullable' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`