### PR TITLE
Update GTLRService.m

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -2474,7 +2474,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
     _objectClassResolver = params.objectClassResolver ?: service.objectClassResolver;
 
     _retryEnabled = (params.retryEnabled ? params.retryEnabled.boolValue : service.retryEnabled);
-    _maxRetryInterval = (params.maxRetryInterval ?
+    _maxRetryInterval = ((params.maxRetryInterval != nil) ?
                          params.maxRetryInterval.doubleValue : service.maxRetryInterval);
     _shouldFetchNextPages = (params.shouldFetchNextPages ?
                              params.shouldFetchNextPages.boolValue : service.shouldFetchNextPages);


### PR DESCRIPTION
Fix static analysis warning
`GTLRService.m:2477:26: Converting a pointer value of type 'NSNumber * _Nullable' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`