### PR TITLE
Update GTLRService.m

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -2476,7 +2476,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
     _retryEnabled = (params.retryEnabled ? params.retryEnabled.boolValue : service.retryEnabled);
     _maxRetryInterval = (params.maxRetryInterval ?
                          params.maxRetryInterval.doubleValue : service.maxRetryInterval);
-    _shouldFetchNextPages = (params.shouldFetchNextPages ?
+    _shouldFetchNextPages = ((params.shouldFetchNextPages != nil)?
                              params.shouldFetchNextPages.boolValue : service.shouldFetchNextPages);
 
     GTLRServiceUploadProgressBlock uploadProgressBlock =


### PR DESCRIPTION
Fix static analysis warning for
`GTLRService.m:2479:30: Converting a pointer value of type 'NSNumber * _Nullable' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue`