### PR TITLE
Use %ld to format an NSInteger.

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -229,8 +229,8 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
               statusString = _statusString;
 #if DEBUG
 - (NSString *)description {
-  return [NSString stringWithFormat:@"%@ %p: %@\n%zd %@\nheaders:%@\nJSON:%@\nerror:%@",
-          [self class], self, self.contentID, self.statusCode, self.statusString,
+  return [NSString stringWithFormat:@"%@ %p: %@\n%ld %@\nheaders:%@\nJSON:%@\nerror:%@",
+          [self class], self, self.contentID, (long)self.statusCode, self.statusString,
           self.headers, self.JSON, self.parseError];
 }
 #endif


### PR DESCRIPTION
Fixes Xcode 9.3 build warning.

The official Apple recommendation for formatting NSIntegers can be found here:

https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html

Fixes issue #203