### PR TITLE
Fix import of GTMMIMEDocument.h

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -37,14 +37,14 @@
 #import "GTLRURITemplate.h"
 #import "GTLRUtilities.h"
 
-#import "GTMMIMEDocument.h"
-
 #if GTLR_USE_FRAMEWORK_IMPORTS
   #import <GTMSessionFetcher/GTMSessionFetcher.h>
   #import <GTMSessionFetcher/GTMSessionFetcherService.h>
+  #import <GTMSessionFetcher/GTMMIMEDocument.h>
 #else
   #import "GTMSessionFetcher.h"
   #import "GTMSessionFetcherService.h"
+  #import "GTMMIMEDocument.h"
 #endif  // GTLR_USE_FRAMEWORK_IMPORTS
 
 


### PR DESCRIPTION
Fix #218.

Use a modular import for `GTMMIMEDocument.h` like the other GTMSessionFetcher headers to enable CocoaPods 1.5.0 static library build to succeed.

Note that this bug reproduction is especially sensitive to Xcode, Xcode module cache, and CocoaPods subspec state, so liberal use of `rm -rf  ~/Library/Developer/Xcode/DerivedData/`, `pod deintegrate` and Xcode restarts are useful for eliminating strange behavior.