### PR TITLE
explicit class at build time

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -864,16 +864,16 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
   if (uploadLocationURL) {
     // Resuming with the session fetcher and a file URL.
     GTLR_DEBUG_ASSERT(uploadFileURL != nil, @"Resume requires a file URL");
-    fetcher = [uploadClass uploadFetcherWithLocation:uploadLocationURL
-                                      uploadMIMEType:uploadMIMEType
-                                           chunkSize:(int64_t)uploadChunkSize
-                                      fetcherService:fetcherService];
+    fetcher = [GTMSessionUploadFetcher uploadFetcherWithLocation:uploadLocationURL
+                                                  uploadMIMEType:uploadMIMEType
+                                                       chunkSize:(int64_t)uploadChunkSize
+                                                  fetcherService:fetcherService];
     fetcher.uploadFileURL = uploadFileURL;
   } else {
-    fetcher = [uploadClass uploadFetcherWithRequest:request
-                                     uploadMIMEType:uploadMIMEType
-                                          chunkSize:(int64_t)uploadChunkSize
-                                     fetcherService:fetcherService];
+    fetcher = [GTMSessionUploadFetcher uploadFetcherWithRequest:request
+                                                 uploadMIMEType:uploadMIMEType
+                                                      chunkSize:(int64_t)uploadChunkSize
+                                                 fetcherService:fetcherService];
     if (uploadFileURL) {
       fetcher.uploadFileURL = uploadFileURL;
     } else if (uploadData) {


### PR DESCRIPTION
Clang analyzer gets sometimes confused or is wasting time to figure out which class has selector `uploadFetcherWithLocation:uploadMIMEType:chunkSize:fetcherService:`. As the method signature of `uploadFetcherWithRequest:fetcherService:params:` already has an explicit `GTMSessionUploadFetcher` return type, it is not necessary to use the non-explicit uploadClass.
