### PR TITLE
Fixed build using Xcode 10 beta 1

### DIFF
--- a/Source/Objects/GTLRObject.m
+++ b/Source/Objects/GTLRObject.m
@@ -400,9 +400,9 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
         // We only want dynamic properties; their attributes contain ",D".
         const char *attr = property_getAttributes(*prop);
         const char *dynamicMarker = strstr(attr, ",D");
-        if (dynamicMarker &&
+        if (propName && dynamicMarker &&
             (dynamicMarker[2] == 0 || dynamicMarker[2] == ',' )) {
-          [array addObject:@(propName)];
+          [array addObject:(id _Nonnull)@(propName)];
         }
       }
       free(properties);

--- a/Source/Objects/GTLRObject.m
+++ b/Source/Objects/GTLRObject.m
@@ -400,7 +400,7 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
         // We only want dynamic properties; their attributes contain ",D".
         const char *attr = property_getAttributes(*prop);
         const char *dynamicMarker = strstr(attr, ",D");
-        if (propName && dynamicMarker &&
+        if (dynamicMarker &&
             (dynamicMarker[2] == 0 || dynamicMarker[2] == ',' )) {
           [array addObject:(id _Nonnull)@(propName)];
         }


### PR DESCRIPTION
```
third_party/objective_c/google_api_objectivec_client_for_rest/Source/Objects/GTLRObject.m:405:28: error: implicit conversion from nullable pointer 'NSString * _Nullable' to non-nullable pointer type 'id _Nonnull' [-Werror,-Wnullable-to-nonnull-conversion]
          [array addObject:@(propName)];
                           ^
```