### PR TITLE
Test/Fixes for -description.

### DIFF
--- a/Source/Objects/GTLRObject.m
+++ b/Source/Objects/GTLRObject.m
@@ -432,7 +432,7 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
 - (NSString *)description {
   NSString *jsonDesc = [self JSONDescription];
 
-  NSString *str = [NSString stringWithFormat:@"%@ %p: {%@}",
+  NSString *str = [NSString stringWithFormat:@"%@ %p: %@",
                    [self class], self, jsonDesc];
   return str;
 }
@@ -442,7 +442,7 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
   // Find the list of declared and otherwise known JSON keys for this class.
   NSArray *knownKeys = [[self class] allKnownKeys];
 
-  NSMutableString *descStr = [NSMutableString string];
+  NSMutableString *descStr = [NSMutableString stringWithString:@"{"];
 
   NSString *spacer = @"";
   for (NSString *key in _json) {
@@ -473,6 +473,7 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
     [descStr appendFormat:@"%@%@%@:%@", spacer, key, qmark, value];
     spacer = @" ";
   }
+  [descStr appendString:@"}"];
   return descStr;
 }
 
@@ -601,7 +602,7 @@ static NSMutableDictionary *gArrayPropertyToClassMapCache = nil;
 - (NSString *)description {
   NSString *jsonDesc = @"";
   if (self.JSON.count > 0) {
-    jsonDesc = [NSString stringWithFormat:@"{%@}", [self JSONDescription]];
+    jsonDesc = [self JSONDescription];
   }
   return [NSString stringWithFormat:@"%@ %p: %tu bytes, contentType:%@ %@",
           [self class], self, self.data.length, self.contentType, jsonDesc];
@@ -649,6 +650,11 @@ static NSMutableDictionary *gArrayPropertyToClassMapCache = nil;
 
   [self setCacheChild:result forKey:cacheKey];
   return result;
+}
+
+- (NSString *)JSONDescription {
+  // Just like GTLRObject's handing of arrays, just return the count.
+  return [NSString stringWithFormat:@"[%tu]", self.JSON.count];
 }
 
 @end


### PR DESCRIPTION
- Hook the -description for the base array object it doesn't
  throw.
- Add tests so it doesn't regress.