### PR TITLE
Prefer HTTP errors over parsing errors.

### DIFF
--- a/Source/Objects/GTLRService.m
+++ b/Source/Objects/GTLRService.m
@@ -806,10 +806,9 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
                 [NSJSONSerialization JSONObjectWithData:(NSData * _Nonnull)data
                                                 options:NSJSONReadingMutableContainers
                                                   error:&parseError];
-            if (parseError) {
-              // We could not parse the JSON payload
-              error = parseError;
-            } else {
+            // If the json parse worked, then extract potentially better
+            // information.
+            if (!parseError) {
               // HTTP Streaming defined by Google services is is an array
               // of requests and replies. This code never makes one of
               // these requests; but, some GET apis can actually be to


### PR DESCRIPTION
If there is an HTTP error, only use the body data for more specific
error information if is was valid json and parsed, if it didn't parse
just fall back to ignoring the response body and just remore the HTTP
error.