### PR TITLE
Make padding optional in WebSafe decode.

### DIFF
--- a/Source/Tests/GTLRBase64Test.m
+++ b/Source/Tests/GTLRBase64Test.m
@@ -31,6 +31,10 @@
                              @"i8WaxanFuMaHxpbGpca0x4PHksehx7A=";
   NSString *testEncodedWeb = @"ARAfLj1MW2p5wojCl8KmwrXDhMOTw6LDscSAxI_EnsStxLzF"
                              @"i8WaxanFuMaHxpbGpca0x4PHksehx7A=";
+  NSString *testEncodedWebNoPadding =
+      [testEncodedWeb stringByTrimmingCharactersInSet:
+         [NSCharacterSet characterSetWithCharactersInString:@"="]];
+  XCTAssertNotEqualObjects(testEncodedWeb, testEncodedWebNoPadding);
 
   // Encoding
   NSData *data = nil;
@@ -58,7 +62,7 @@
   data = GTLRDecodeBase64(str);
   XCTAssertNil(data, @"nil string");
 
-  str = @"kjh"; // not valid base64
+  str = @"kjh"; // not valid base64 (not padded correctly)
   data = GTLRDecodeBase64(str);
   XCTAssertNil(data, @"invalid string");
 
@@ -75,5 +79,11 @@
   data = GTLRDecodeWebSafeBase64(str);
   expectedData = [testStr dataUsingEncoding:NSUTF8StringEncoding];
   XCTAssertEqualObjects(data, expectedData, @"test string ws");
+
+  str = testEncodedWebNoPadding;
+  data = GTLRDecodeWebSafeBase64(str);
+  expectedData = [testStr dataUsingEncoding:NSUTF8StringEncoding];
+  XCTAssertEqualObjects(data, expectedData);
 }
+
 @end

--- a/Source/Utilities/GTLRBase64.m
+++ b/Source/Utilities/GTLRBase64.m
@@ -79,13 +79,14 @@ static void CreateDecodingTable(const char *encodingTable,
 }
 
 static NSData *DecodeBase64StringCommon(NSString *base64Str,
-                                        char *decodingTable) {
+                                        char *decodingTable,
+                                        BOOL requirePadding) {
   // The input string should be plain ASCII
   const char *cString = [base64Str cStringUsingEncoding:NSASCIIStringEncoding];
   if (cString == nil) return nil;
 
   NSInteger inputLength = (NSInteger)strlen(cString);
-  if (inputLength % 4 != 0) return nil;
+  if (requirePadding && (inputLength % 4 != 0)) return nil;
   if (inputLength == 0) return [NSData data];
 
   while (inputLength > 0 && cString[inputLength - 1] == '=') {
@@ -127,7 +128,7 @@ NSData *GTLRDecodeBase64(NSString *base64Str) {
                         decodingTable);
     hasInited = YES;
   }
-  return DecodeBase64StringCommon(base64Str, decodingTable);
+  return DecodeBase64StringCommon(base64Str, decodingTable, YES /* requirePadding */ );
 }
 
 NSData *GTLRDecodeWebSafeBase64(NSString *base64Str) {
@@ -139,5 +140,5 @@ NSData *GTLRDecodeWebSafeBase64(NSString *base64Str) {
                         decodingTable);
     hasInited = YES;
   }
-  return DecodeBase64StringCommon(base64Str, decodingTable);
+  return DecodeBase64StringCommon(base64Str, decodingTable, NO /* requirePadding */);
 }


### PR DESCRIPTION
It might make sense in the future to provide an option to skip added the
padding during encode also (to help when needing the value for a URL param).