### PR TITLE
Properly support NSSecureCoding by listing needed classes.

### DIFF
--- a/Source/Objects/GTLRObject.m
+++ b/Source/Objects/GTLRObject.m
@@ -123,8 +123,14 @@ static NSMutableDictionary *DeepMutableCopyOfJSONDictionary(NSDictionary *initia
 - (instancetype)initWithCoder:(NSCoder *)decoder {
   self = [super init];
   if (self) {
-    _json = [decoder decodeObjectOfClass:[NSMutableDictionary class]
-                                  forKey:kGTLRObjectJSONCoderKey];
+    // NSDictionary/NSArray seem to allow strings and numbers with secure coding
+    // just fine, but to allow sub arrays or dictionaries (or an null) the
+    // classes have to be explicitly listed to decode correctly.
+    NSSet *expectedClasses =
+        [NSSet setWithObjects:
+           [NSMutableDictionary class], [NSMutableArray class], [NSNull class], nil];
+    _json = [decoder decodeObjectOfClasses:expectedClasses
+                                    forKey:kGTLRObjectJSONCoderKey];
   }
   return self;
 }


### PR DESCRIPTION
While not clear from the docs, it seems NSDictionary/NSArray when using
SecureCoding will extract strings and numbers just fine, they don't like other
classes unless explicitly listed.

Fixes #298