### PR TITLE
Restrict the gtm-session-fetcher dep to < 2.0.

### DIFF
--- a/GoogleAPIClientForREST.podspec
+++ b/GoogleAPIClientForREST.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   # Require at least 1.6.1 of the SessionFetcher since it has the same
   # deployment targets.
-  s.dependency 'GTMSessionFetcher', '>= 1.6.1'
+  s.dependency 'GTMSessionFetcher', '>= 1.6.1', '< 2.0'
 
   s.subspec 'Core' do |sp|
     sp.source_files = 'Source/GTLRDefines.h',

--- a/Package.swift
+++ b/Package.swift
@@ -954,7 +954,7 @@ let package = Package(
         // End of products.
     ],
     dependencies: [
-        .package(url: "https://github.com/google/gtm-session-fetcher.git", from: "1.4.0")
+        .package(url: "https://github.com/google/gtm-session-fetcher.git", "1.6.1" ..< "2.0.0"),
     ],
     targets: [
         .target(

--- a/Source/Tools/Package.swift
+++ b/Source/Tools/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/google/gtm-session-fetcher.git", from: "1.4.0"),
+        .package(url: "https://github.com/google/gtm-session-fetcher.git", "1.6.1" ..< "2.0.0"),
         .package(path: "../..")
     ],
     targets: [


### PR DESCRIPTION
Restrict things to since the next major release of the session fetcher is going
to shuffle some packaging to improve things, this should avoid picking up that
update until after this project can also get updated.

Also fix the min version in the SwiftPM files.