### PR TITLE
No errors for deprecated-declarations.

### DIFF
--- a/Examples/CalendarSample/CalendarSample.xcodeproj/project.pbxproj
+++ b/Examples/CalendarSample/CalendarSample.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Debug;
@@ -413,6 +414,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Release;

--- a/Examples/DriveSample/DriveSample.xcodeproj/project.pbxproj
+++ b/Examples/DriveSample/DriveSample.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Debug;
@@ -405,6 +406,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Release;

--- a/Examples/StorageSample/StorageSample.xcodeproj/project.pbxproj
+++ b/Examples/StorageSample/StorageSample.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Debug;
@@ -405,6 +406,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Release;

--- a/Examples/YouTubeSample/YouTubeSample.xcodeproj/project.pbxproj
+++ b/Examples/YouTubeSample/YouTubeSample.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Debug;
@@ -381,6 +382,7 @@
 				WARNING_CFLAGS = (
 					"-Wall",
 					"-Werror",
+					"-Wno-error=deprecated-declarations",
 				);
 			};
 			name = Release;


### PR DESCRIPTION
AppAuth is directly using `__deprecated_msg`, so keep that from erroring the build.