### PR TITLE
Add xcpretty to xcodebuilds to shorten output.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,14 @@ jobs:
             DESTINATION="platform=WatchOS Simulator,name=Apple Watch Series 7 - 45mm,OS=latest"
             ;;
         esac
+        set -o pipefail
         xcodebuild \
-          -project Source/GTLRCore.xcodeproj \
-          -scheme "${XCODE_SCHEME}" \
-          -configuration ${{ matrix.CONFIGURATION }} \
-          -destination "${DESTINATION}" \
-          build test
+            -project Source/GTLRCore.xcodeproj \
+            -scheme "${XCODE_SCHEME}" \
+            -configuration ${{ matrix.CONFIGURATION }} \
+            -destination "${DESTINATION}" \
+            build test \
+          | xcpretty
 
   service_generator:
     needs: core
@@ -72,8 +74,10 @@ jobs:
     - name: Build and Test
       run:  |
         set -eu
+        set -o pipefail
         xcodebuild \
-          -project Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj \
-          -scheme "ServiceGenerator" \
-          -configuration ${{ matrix.CONFIGURATION }} \
-          build
+            -project Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj \
+            -scheme "ServiceGenerator" \
+            -configuration ${{ matrix.CONFIGURATION }} \
+            build \
+          | xcpretty

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -75,17 +75,21 @@ jobs:
             ;;
         esac
 
+        set -o pipefail
         xcodebuild \
-          -scheme GoogleAPIClientForREST-Package \
-          -configuration ${{ matrix.CONFIGURATION }} \
-          -destination "${DESTINATION}" \
-          build test
+            -scheme GoogleAPIClientForREST-Package \
+            -configuration ${{ matrix.CONFIGURATION }} \
+            -destination "${DESTINATION}" \
+            build test \
+          | xcpretty
     - name: Build ServiceGenerator
       if: ${{ matrix.CONFIGURATION == 'macos' }}
       run:  |
         set -eu
         cd Source/Tools
+        set -o pipefail
         xcodebuild \
-          -scheme GTLR_ServiceGenerator \
-          -configuration ${{ matrix.CONFIGURATION }} \
-          build
+            -scheme GTLR_ServiceGenerator \
+            -configuration ${{ matrix.CONFIGURATION }} \
+            build \
+          | xcpretty


### PR DESCRIPTION
Old scripts used to conditionally add it, so this gets the same reduced output.