### PR TITLE
Drop the attempt at SwiftPM detection.

### DIFF
--- a/Tools/ServiceGenerator/SGGenerator.m
+++ b/Tools/ServiceGenerator/SGGenerator.m
@@ -2897,9 +2897,7 @@ static NSString *MappedParamInterfaceName(NSString *name, BOOL takesObject, BOOL
   }
 
   NSMutableString *result = [NSMutableString string];
-  [result appendString:@"#if defined(SWIFT_PACKAGE) && SWIFT_PACKAGE\n"];
-  [result appendString:@"  @import GoogleAPIClientForRESTCore;\n"];
-  [result appendFormat:@"#elif __has_include(<GoogleAPIClientForREST/%@.h>)\n", headerName];
+  [result appendFormat:@"#if __has_include(<GoogleAPIClientForREST/%@.h>)\n", headerName];
   [result appendFormat:@"  #import <GoogleAPIClientForREST/%@.h>\n", headerName];
   [result appendString:@"#else\n"];
   [result appendFormat:@"  #import \"%@.h\"\n", headerName];


### PR DESCRIPTION
Where the generated code is compiled (SwiftPM or not) has nothing to do with how
GTLR was compiled, so using `SWIFT_PACKAGE` to gate how things should be
included isn't very reliable. Just use `_can_include` like Firebase dones, for a
simpler flow that will hopefully work out correctly in most cases now that the
imports are standardized for ObjC between SwiftPM and CocoaPods. Failing that
the generator has flags to let folks control the stuff they generated.