### PR TITLE
Suppress warnings for the session fetcher authorizer changes.

### DIFF
--- a/Sources/Core/GTLRService.m
+++ b/Sources/Core/GTLRService.m
@@ -129,7 +129,10 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
 // Internal properties copied from the service.
 @property(nonatomic, assign) BOOL allowInsecureQueries;
 @property(nonatomic, strong) GTMSessionFetcherService *fetcherService;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 @property(nonatomic, strong, nullable) id<GTMFetcherAuthorizationProtocol> authorizer;
+#pragma clang diagnostic pop
 
 // Internal properties copied from serviceExecutionParameters.
 @property(nonatomic, getter=isRetryEnabled) BOOL retryEnabled;
@@ -2286,6 +2289,8 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
   return props;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 - (void)setAuthorizer:(id <GTMFetcherAuthorizationProtocol>)authorizer {
   self.fetcherService.authorizer = authorizer;
 }
@@ -2293,6 +2298,7 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
 - (id <GTMFetcherAuthorizationProtocol>)authorizer {
   return self.fetcherService.authorizer;
 }
+#pragma clang diagnostic pop
 
 + (NSUInteger)defaultServiceUploadChunkSize {
   // Subclasses may override this method.
@@ -2531,7 +2537,10 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
   }
 
   NSString *authorizerInfo = @"";
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id <GTMFetcherAuthorizationProtocol> authorizer = self.objectFetcher.authorizer;
+#pragma clang diagnostic pop
   if (authorizer != nil) {
     authorizerInfo = [NSString stringWithFormat:@" authorizer:%@", authorizer];
   }

--- a/Sources/Core/Public/GoogleAPIClientForREST/GTLRService.h
+++ b/Sources/Core/Public/GoogleAPIClientForREST/GTLRService.h
@@ -295,12 +295,18 @@ typedef void (^GTLRServiceTestBlock)(GTLRServiceTicket *testTicket,
  */
 - (void)setMainBundleIDRestrictionWithAPIKey:(NSString *)apiKey;
 
+// Avoid the warnings for GTMFetcherAuthorizationProtocol in newer
+// GTMSessionFetcher headers. Updating requires a new minimum, and
+// holding of on raising it that current for the moment.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 /**
  *  An authorizer adds user authentication headers to the request as needed.
  *
  *  This may be overridden on individual queries with the @c shouldSkipAuthorization property.
  */
 @property(nonatomic, retain, nullable) id <GTMFetcherAuthorizationProtocol> authorizer;
+#pragma clang diagnostic pop
 
 /**
  *  Enable fetcher retry support.  See the explanation of retry support in @c GTMSessionFetcher.h

--- a/UnitTests/GTLRServiceTest.m
+++ b/UnitTests/GTLRServiceTest.m
@@ -70,6 +70,8 @@
 // Simple authorizer class for testing
 //
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 @interface GTLRTestAuthorizer : NSObject <GTMFetcherAuthorizationProtocol>
 // The value string will be added to the authorization header, like
 // Authorization: Bearer value
@@ -78,6 +80,7 @@
 @property(atomic, copy) NSString *value;
 @property(atomic, retain) NSError *error;
 @end
+#pragma clang diagnostic pop
 
 // GTLRTestLifetimeObject fulfills the expectation when the provided object deallocates.
 //
@@ -486,7 +489,10 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
 
   // The fetcher releases its authorizer upon completion, so to test the request,
   // we'll use the service's authorizer.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorizer = service.authorizer;
+#pragma clang diagnostic pop
   XCTAssertNotNil(authorizer);
   XCTAssert([authorizer isAuthorizedRequest:fetcherRequest],
             @"%@", fetcherRequest.allHTTPHeaderFields);
@@ -628,7 +634,10 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
 
   // The fetcher releases its authorizer upon completion, so to test the request,
   // we'll use the service's authorizer.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorizer = service.authorizer;
+#pragma clang diagnostic pop
   XCTAssertNotNil(authorizer);
   XCTAssert([authorizer isAuthorizedRequest:fetcherRequest],
             @"%@", fetcherRequest.allHTTPHeaderFields);
@@ -922,7 +931,10 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
   XCTAssert(queryTicket.hasCalledCallback);
 
   // Authorization should have been skipped.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorizer = service.authorizer;
+#pragma clang diagnostic pop
   NSURLRequest *fetcherRequest = queryTicket.objectFetcher.request;
   XCTAssertNotNil(authorizer);
   XCTAssertFalse([authorizer isAuthorizedRequest:fetcherRequest],
@@ -1678,7 +1690,10 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
   XCTAssert([part2BodyStr hasPrefix:expectedBodyGet], @"%@", part2BodyStr);
 
   // Verify authorization.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorizer = service.authorizer;
+#pragma clang diagnostic pop
   XCTAssertNotNil(authorizer);
   bool didAuthorize = [authorizer isAuthorizedRequest:fetcherRequest];
   XCTAssertEqual(didAuthorize, !shouldSkipAuthorization, @"%@", fetcherRequest.allHTTPHeaderFields);
@@ -3516,6 +3531,16 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
   return str;
 }
 
+- (void)authorizeRequest:(nullable NSMutableURLRequest *)request
+       completionHandler:(void (^)(NSError *_Nullable error))handler {
+  NSString *str = [self authorizationValue];
+  [request setValue:str forHTTPHeaderField:@"Authorization"];
+
+  handler(_error);
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)authorizeRequest:(NSMutableURLRequest *)request
                 delegate:(id)delegate
        didFinishSelector:(SEL)sel {
@@ -3532,6 +3557,7 @@ static BOOL IsCurrentQueue(dispatch_queue_t targetQueue) {
   [invocation setArgument:&_error atIndex:4];
   [invocation invoke];
 }
+#pragma clang diagnostic pop
 
 - (void)stopAuthorization {
 }


### PR DESCRIPTION
Moving to the new protocol would require raising the min version, holding off on
that for the time being.