### PR TITLE
Use --fail-fast with `pod lib lint`

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Pod lib lint
       run:  |
         pod lib lint --verbose \
+          --fail-fast \
           --configuration=${{ matrix.CONFIGURATION }} \
           --platforms=${{ matrix.PLATFORM }} \
           GoogleAPIClientForREST.podspec
@@ -55,6 +56,7 @@ jobs:
     - name: Pod lib lint - Use Static Frameworks
       run:  |
         pod lib lint --verbose --use-static-frameworks \
+          --fail-fast \
           --configuration=${{ matrix.CONFIGURATION }} \
           --platforms=${{ matrix.PLATFORM }} \
           GoogleAPIClientForREST.podspec


### PR DESCRIPTION
Most of the time when things fail, it's in the Core pod, so fail fast to see the
failure instead of waiting for everything to finish and repeat the error across
all the subspecs.