### PR TITLE
Suppress warnings for the session fetcher authorizer changes.

### DIFF
--- a/Examples/CalendarSample/CalendarSampleWindowController.m
+++ b/Examples/CalendarSample/CalendarSampleWindowController.m
@@ -95,8 +95,11 @@ NSString *const kGTMAppAuthKeychainItemName = @"CalendarSample: Google Calendar.
 
 - (void)awakeFromNib {
   // Attempts to deserialize authorization from keychain in GTMAppAuth format.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorization =
       [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:kGTMAppAuthKeychainItemName];
+#pragma clang diagnostic pop
   self.calendarService.authorizer = authorization;
 
   // Set the result text fields to have a distinctive color and mono-spaced font
@@ -114,7 +117,10 @@ NSString *const kGTMAppAuthKeychainItemName = @"CalendarSample: Google Calendar.
 
 - (NSString *)signedInUsername {
   // Get the email address of the signed-in user
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> auth = self.calendarService.authorizer;
+#pragma clang diagnostic pop
   BOOL isSignedIn = auth.canAuthorize;
   if (isSignedIn) {
     return auth.userEmail;

--- a/Examples/DriveSample/DriveSampleWindowController.m
+++ b/Examples/DriveSample/DriveSampleWindowController.m
@@ -85,8 +85,11 @@ NSString *const kGTMAppAuthKeychainItemName = @"DriveSample: Google Drive. GTMAp
 
 - (void)awakeFromNib {
   // Attempts to deserialize authorization from keychain in GTMAppAuth format.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorization =
       [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:kGTMAppAuthKeychainItemName];
+#pragma clang diagnostic pop
   self.driveService.authorizer = authorization;
 
   // Set the result text fields to have a distinctive color and mono-spaced font.
@@ -104,7 +107,10 @@ NSString *const kGTMAppAuthKeychainItemName = @"DriveSample: Google Drive. GTMAp
 
 - (NSString *)signedInUsername {
   // Get the email address of the signed-in user.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> auth = self.driveService.authorizer;
+#pragma clang diagnostic pop
   BOOL isSignedIn = auth.canAuthorize;
   if (isSignedIn) {
     return auth.userEmail;

--- a/Examples/StorageSample/StorageSampleWindowController.m
+++ b/Examples/StorageSample/StorageSampleWindowController.m
@@ -79,8 +79,11 @@ NSString *const kGTMAppAuthKeychainItemName = @"StorageSample: Google Cloud Stor
 
 - (void)awakeFromNib {
   // Attempts to deserialize authorization from keychain in GTMAppAuth format.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorization =
       [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:kGTMAppAuthKeychainItemName];
+#pragma clang diagnostic pop
   self.storageService.authorizer = authorization;
 
   // Set the result text fields to have a distinctive color and mono-spaced font.
@@ -98,7 +101,10 @@ NSString *const kGTMAppAuthKeychainItemName = @"StorageSample: Google Cloud Stor
 
 - (NSString *)signedInUsername {
   // Get the email address of the signed-in user.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> auth = self.storageService.authorizer;
+#pragma clang diagnostic pop
   BOOL isSignedIn = auth.canAuthorize;
   if (isSignedIn) {
     return auth.userEmail;

--- a/Examples/YouTubeSample/YouTubeSampleWindowController.m
+++ b/Examples/YouTubeSample/YouTubeSampleWindowController.m
@@ -80,8 +80,11 @@ NSString *const kGTMAppAuthKeychainItemName = @"YouTubeSample: YouTube. GTMAppAu
 
 - (void)awakeFromNib {
   // Attempts to deserialize authorization from keychain in GTMAppAuth format.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> authorization =
       [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:kGTMAppAuthKeychainItemName];
+#pragma clang diagnostic pop
   self.youTubeService.authorizer = authorization;
 
   // Set the result text fields to have a distinctive color and mono-spaced font.
@@ -102,7 +105,10 @@ NSString *const kGTMAppAuthKeychainItemName = @"YouTubeSample: YouTube. GTMAppAu
 
 - (NSString *)signedInUsername {
   // Get the email address of the signed-in user.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
   id<GTMFetcherAuthorizationProtocol> auth = self.youTubeService.authorizer;
+#pragma clang diagnostic pop
   BOOL isSignedIn = auth.canAuthorize;
   if (isSignedIn) {
     return auth.userEmail;


### PR DESCRIPTION
Moving to the new protocol would require raising the min version, holding off on that for the time being.