### PR TITLE
Update the reserved words check.

### DIFF
--- a/Tools/ServiceGenerator/SGUtils.h
+++ b/Tools/ServiceGenerator/SGUtils.h
@@ -141,7 +141,11 @@
 // Returns the list of selector names for the given class that take no args and
 // don't appear to be private (i.e. - they could collide with properties on
 // subclasses).
-+ (NSArray<NSString *> *)publicNoArgSelectorsForClass:(Class)aClass;
+//
+// skipPrefixed can be used to skip selectors that appear to be prefixed
+// as those are likely things added via categories and not really public.
++ (NSArray<NSString *> *)publicNoArgSelectorsForClass:(Class)aClass
+                                         skipPrefixed:(BOOL)skipPrefixed;
 
 @end
 

--- a/Tools/ServiceGenerator/SGUtils.m
+++ b/Tools/ServiceGenerator/SGUtils.m
@@ -637,7 +637,19 @@ static const NSUInteger kMaxWidth = 80;
 
 #pragma mark -
 
-+ (NSArray *)publicNoArgSelectorsForClass:(Class)aClass {
+static BOOL AppearsToBePrefixed(NSString *str) {
+  NSArray<NSString*> *parts = [str componentsSeparatedByString:@"_"];
+  // Only count a single underscore in the name as meaning there's a possible
+  // prefix on the selector.
+  if (parts.count != 2) {
+    return NO;
+  }
+  // If the first segment is <=5 characters, call it a prefix.
+  return (parts[0].length <= 5);
+}
+
++ (NSArray *)publicNoArgSelectorsForClass:(Class)aClass
+                             skipPrefixed:(BOOL)skipPrefixed {
   unsigned int count;
   Method *methodList = class_copyMethodList(aClass, &count);
 
@@ -652,6 +664,8 @@ static const NSUInteger kMaxWidth = 80;
       // starts with/ends with underscore, internal.
     } else if ([str hasPrefix:@"."]) {
       // starts with period, also internal.
+    } else if (skipPrefixed && AppearsToBePrefixed(str)) {
+      // starts with a prefix, probably a category addition, skip it.
     } else {
       [result addObject:str];
     }


### PR DESCRIPTION
Add generic support for skipping things that look like they are prefixed selectors as that tends to be category additions, and not checking them for NSObject will shorten the list.