### PR TITLE
Add xcprivacy manifest info.

### DIFF
--- a/GoogleAPIClientForREST.podspec
+++ b/GoogleAPIClientForREST.podspec
@@ -34,6 +34,9 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |sp|
     sp.source_files = 'Sources/Core/**/*.{h,m}'
     sp.public_header_files = 'Sources/Core/Public/GoogleAPIClientForREST/*.h'
+    sp.resource_bundle = {
+      "GoogleAPIClientForREST_Privacy" => "Sources/Core/Resources/PrivacyInfo.xcprivacy"
+    }
   end
 
   s.test_spec 'Tests' do |sp|

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -1117,8 +1117,13 @@ let package = Package(
     targets: [
         .target(
             name: "GoogleAPIClientForRESTCore",
-            dependencies: ["GTMSessionFetcherFull"],
+            dependencies: [
+              .product(name: "GTMSessionFetcherFull", package: "gtm-session-fetcher")
+            ],
             path: "Sources/Core",
+            resources: [
+              .process("Resources/PrivacyInfo.xcprivacy")
+            ],
             publicHeadersPath: "Public"
         ),
         .testTarget(

--- a/Sources/Core/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Core/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
There are no calls within the library to the apis that need reasons, so the manifest is empty.