### PR TITLE
Deprecate GTLRTicket.fetchRequest

### DIFF
--- a/Sources/Core/Public/GoogleAPIClientForREST/GTLRService.h
+++ b/Sources/Core/Public/GoogleAPIClientForREST/GTLRService.h
@@ -770,7 +770,8 @@ typedef void (^GTLRServiceTestBlock)(GTLRServiceTicket *testTicket,
 /**
  *  The request being fetched for the query.
  */
-@property(nonatomic, readonly, nullable) NSURLRequest *fetchRequest;
+@property(nonatomic, readonly, nullable) NSURLRequest *fetchRequest __attribute__((deprecated(
+    "To be removed. Blocks the calling thread to eagerly calculate the User-Agent string.")));
 
 /**
  *  The fetcher being used for the query request.


### PR DESCRIPTION
This API has to block the caller to synchronously format the User-Agent string on the calling thread, which can cause UI hangs and stalls.

This PR marks it deprecated so we can remove it in a future release.
