### PR TITLE
[Cleanup] Remove method +[GTLRService ticketClass]

### DIFF
--- a/Sources/Core/GTLRService.m
+++ b/Sources/Core/GTLRService.m
@@ -245,10 +245,6 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
             uploadProgressBlock = _uploadProgressBlock,
             userAgentAddition = _userAgentAddition;
 
-+ (Class)ticketClass {
-  return [GTLRServiceTicket class];
-}
-
 - (instancetype)init {
   self = [super init];
   if (self) {
@@ -502,8 +498,8 @@ static NSDictionary *MergeDictionaries(NSDictionary *recessiveDict, NSDictionary
 
   // We need to create a ticket unless one was created earlier (like during authentication.)
   if (!ticket) {
-    ticket = [[[[self class] ticketClass] alloc] initWithService:self
-                                             executionParameters:executionParams];
+    ticket = [[GTLRServiceTicket alloc] initWithService:self
+                                    executionParameters:executionParams];
     [ticket notifyStarting:YES];
   }
 


### PR DESCRIPTION
`+[GTLRService ticketClass]` is not part of the public API, and there is only one `GTLRServiceTicket` class, so there's no need for this factory method.

This PR removes it.