### PR TITLE
Move to actions/checkout@v4 to avoid warnings.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -31,7 +31,7 @@ jobs:
         pod_configuration: ["Debug", "Release"]
         extra_flags: ["", "--use-static-frameworks"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Need cocoapods 1.12+ for watchOS to work again.
     - name: Update Cocoapods
       run: gem update cocoapods
@@ -64,7 +64,7 @@ jobs:
       matrix:
         pod_configuration: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: "macOS"
       run:  |
         pod lib lint --verbose \

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         SAMPLE: ["Calendar", "Drive", "YouTube", "Storage"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Debug
       run:  |
         set -eu

--- a/.github/workflows/service_generator.yml
+++ b/.github/workflows/service_generator.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         CONFIGURATION: ["debug", "release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build ServiceGenerator
       run:  |
         set -eu
@@ -49,7 +49,7 @@ jobs:
       matrix:
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build ServiceGenerator
       run:  |
         set -eu

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         CONFIGURATION: ["debug", "release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Test Library
       run:  |
         set -eu
@@ -47,7 +47,7 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Test Library
       run:  |
         set -eu


### PR DESCRIPTION
Current CI runs are reporting:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.