### PR TITLE
Stop forcing Xcode versions and cocoapods updates.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -32,11 +32,12 @@ jobs:
         extra_flags: ["", "--use-static-frameworks"]
     steps:
     - uses: actions/checkout@v4
-    - name: "iOS, macOS, tvOS, and visionOS"
+    - name: "iOS, macOS, and tvOS"
+      # GitHub runners dropped visionOS. https://github.com/actions/runner-images/issues/10559
       run:  |
         pod lib lint --verbose ${{ matrix.extra_flags }} \
           --configuration=${{ matrix.pod_configuration }} \
-          --platforms=ios,macos,tvos,visionos \
+          --platforms=ios,macos,tvos \
           --no-subspecs \
           --test-specs=Tests \
           GoogleAPIClientForREST.podspec

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -31,13 +31,7 @@ jobs:
         pod_configuration: ["Debug", "Release"]
         extra_flags: ["", "--use-static-frameworks"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
-    # The "macos-14" image has CocoaPods 1.14.x, and 1.15 is needed for visionOS
-    - name: Update CocoaPods
-      run: gem install cocoapods
     - name: "iOS, macOS, tvOS, and visionOS"
       run:  |
         pod lib lint --verbose ${{ matrix.extra_flags }} \
@@ -67,9 +61,6 @@ jobs:
       matrix:
         pod_configuration: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: "macOS"
       run:  |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,9 +37,6 @@ jobs:
       matrix:
         SAMPLE: ["Calendar", "Drive", "YouTube", "Storage"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build Debug
       run:  |

--- a/.github/workflows/service_generator.yml
+++ b/.github/workflows/service_generator.yml
@@ -49,9 +49,6 @@ jobs:
       matrix:
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build ServiceGenerator
       run:  |

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -44,7 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PLATFORM: ["ios", "macos", "tvos", "watchos", "visionos"]
+        # GitHub runners dropped visionOS. https://github.com/actions/runner-images/issues/10559
+        PLATFORM: ["ios", "macos", "tvos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -30,9 +30,6 @@ jobs:
       matrix:
         CONFIGURATION: ["debug", "release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build and Test Library
       run:  |
@@ -50,9 +47,6 @@ jobs:
         PLATFORM: ["ios", "macos", "tvos", "watchos", "visionos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
-    # The "macos-14" image defaults to 15.0.1, select the newer Xcode.
-    - name: Xcode version
-      run: sudo xcode-select -switch /Applications/Xcode_15.2.app
     - uses: actions/checkout@v4
     - name: Build and Test Library
       run:  |


### PR DESCRIPTION
The base images are advanced enough that these don't need to be controlled any more.