### PR TITLE
Bring back iOS 12 support.

### DIFF
--- a/GoogleAPIClientForREST.podspec
+++ b/GoogleAPIClientForREST.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   # bundle for the privacy manifest.
   s.cocoapods_version = '>= 1.12.0'
 
-  ios_deployment_target = '13.0'
+  ios_deployment_target = '12.0'
   osx_deployment_target = '10.15'
   tvos_deployment_target = '13.0'
   visionos_deployment_target = '1.0'

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "GoogleAPIClientForREST",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v12),
         .macOS(.v10_15),
         .tvOS(.v13),
         .watchOS(.v7)


### PR DESCRIPTION
Firebase's Package.swift still has iOS 12, so GTMSessionFetcher is bring it back so align here also.