### PR TITLE
Bring back visionOS SwiftPM testing.

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -44,8 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # GitHub runners dropped visionOS. https://github.com/actions/runner-images/issues/10559
-        PLATFORM: ["ios", "macos", "tvos", "watchos"]
+        PLATFORM: ["ios", "macos", "tvos", "visionos", "watchos"]
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The CocoaPods builds validations seem to require a simulator.