### PR TITLE
Stop selecting the latest Xcode and use the image default.

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -32,10 +32,6 @@ jobs:
         extra_flags: ["", "--use-static-frameworks"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: "iOS, macOS, tvOS, and visionOS"
       run:  |
         pod lib lint --verbose ${{ matrix.extra_flags }} \
@@ -66,10 +62,6 @@ jobs:
         pod_configuration: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: "macOS"
       run:  |
         pod lib lint --verbose \

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -38,10 +38,6 @@ jobs:
         SAMPLE: ["Calendar", "Drive", "YouTube", "Storage"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build Debug
       run:  |
         set -eu

--- a/.github/workflows/service_generator.yml
+++ b/.github/workflows/service_generator.yml
@@ -36,10 +36,6 @@ jobs:
         CONFIGURATION: ["debug", "release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build ServiceGenerator
       run:  |
         set -eu
@@ -54,10 +50,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build ServiceGenerator
       run:  |
         set -eu

--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -31,10 +31,6 @@ jobs:
         CONFIGURATION: ["debug", "release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test Library
       run:  |
         set -eu
@@ -52,10 +48,6 @@ jobs:
         CONFIGURATION: ["Debug", "Release"]
     steps:
     - uses: actions/checkout@v5
-    - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: 'latest-stable'
     - name: Build and Test Library
       run:  |
         set -eu


### PR DESCRIPTION
The latest GitHub images have the 26 RC, but they didn't install any defaults with that OS, so it makes actions fail. So just go back to using the default Xcode on the images.